### PR TITLE
Booking restrictions and re added booking accept/reject code in the bookings#index

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -20,10 +20,11 @@ class BookingsController < ApplicationController
     @trip = Trip.find(params[:trip_id])
     @booking.user = @user
     @booking.trip = @trip
+
     if @trip.user == @user
       flash.alert = "You cannot book a trip you organized!"
       render 'new', status: :unprocessable_entity
-    elsif @user.bookings.include?(@booking)
+    elsif booked_already?(@user.bookings, @trip.id)
       flash.alert = "You have already booked this trip!"
       render 'new', status: :unprocessable_entity
     else
@@ -53,7 +54,14 @@ class BookingsController < ApplicationController
   private
 
   def booking_params
-  # TODO: check your model, might be different than mine
-  params.require(:booking).permit(:booking_status)
+    params.require(:booking).permit(:booking_status)
+  end
+
+  def booked_already?(user_bookings, trip_id)
+    bookings = []
+    user_bookings.map do |booking|
+      bookings << booking.trip_id
+    end
+    bookings.include?(trip_id)
   end
 end

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -37,7 +37,7 @@ class TripsController < ApplicationController
   def destroy
     @trip = Trip.find(params[:id])
     @trip.destroy
-    redirect_to trips_path, status: :see_other
+    redirect_to bookings_path, status: :see_other
   end
 
   private

--- a/app/views/bookings/index.html.erb
+++ b/app/views/bookings/index.html.erb
@@ -1,4 +1,6 @@
 <div class="container container-trip">
+  <h1>Hello <%= @user.first_name %>!</h1><%# I added first_name temporarily so I know which user is currently logged in %>
+
   <h1><i class="fa-solid fa-plane"></i> My Trips</h1>
 
   <div class="cards-trips">
@@ -11,9 +13,9 @@
           </div>
         <% end %>
         <div class="card-trip-status">
-            <span class ="request-color">Pending <%= trip.bookings.where(booking_status: 0).count %></span>
-            <span class ="approve-color">Confirmed  <%= trip.bookings.where(booking_status: 1).count %></span>
-            <span class ="reject-color"> Cancelled <%= trip.bookings.where(booking_status: 0).count %></span>
+            <span class ="request-color">Pending <%= trip.bookings.where(booking_status: 1).count %></span>
+            <span class ="approve-color">Confirmed  <%= trip.bookings.where(booking_status: 2).count %></span>
+            <span class ="reject-color"> Cancelled <%= trip.bookings.where(booking_status: 3).count %></span>
         </div>
       <% end %>
     </div>
@@ -57,3 +59,70 @@
     </div>
   <% end %>
 </div>
+
+<%# Booking accept/reject --START-- %>
+<%# We definitely need a different component for the booking request since it is not showing properly %>
+<div class="container container-booking">
+  <h1><i class="fa-solid fa-suitcase"></i> Pending Booking Requests</h1>
+
+  <% @trips.each do |trip| %>
+    <div class="card-booking">
+      <div class="card-image">
+        <%= link_to trip_path(trip), class: 'card-booking-link' do %>
+        <% if trip.image_url.present? %>
+          <%= image_tag trip.image_url %>
+        <% end %>
+      </div>
+
+      <div class="card-booking-infos">
+        <div class="card-booking-trip-info">
+          <h3><%= trip.trip_date %></h3>
+          <h2><%= trip.title %></h2>
+        </div>
+        <% end %>
+
+        <div class="d-flex flex-column card-booking-trip-status">
+          <ul>
+          <% trip.bookings.each do |booking| %>
+            <li>
+                <% case booking.booking_status %>
+                <% when 1 %>
+                  <div class="d-flex align-items-center">
+                    <p class="me-auto"><%= booking.user.first_name %> (<%= booking.user.email %>)</p>
+                    <div class="align-self-center mx-2">
+                      <%= simple_form_for booking do |f| %>
+                        <%= f.input :booking_status, as: :hidden, input_html: { value: '2'} %>
+                        <%= f.submit 'Accept', class: 'btn btn-tripl' %>
+                      <% end %>
+                    </div>
+                    <div class="align-self-center p-0 m-2">
+                      <%= simple_form_for booking do |f| %>
+                        <%= f.input :booking_status, as: :hidden, input_html: { value: '3'} %>
+                        <%= f.submit 'Reject', class: 'btn btn-tripl-danger' %>
+                      <% end %>
+                    </div>
+                  </div>
+
+                <%# We can remove case 2 and 3 because it makes more sense to only show the pending bookings, right? %>
+                <% when 2 %>
+                  <p>Booking accepted for <%= booking.user.first_name %></p>
+                <% when 3 %>
+                  <p>Booking rejected for <%= booking.user.first_name %></p>
+                <% end %>
+              <% end %>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <div class="card-bucket">
+      <%= link_to trip_path(trip.id), class: "card-delete-icon-link",
+        data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to delete this trip?"} do %>
+          <i class="fa-solid fa-trash fa-xs"></i>
+      <% end %>
+    </div>
+
+  <% end %>
+</div>
+<%# Booking accept/reject --END-- %>

--- a/app/views/bookings/index.html.erb
+++ b/app/views/bookings/index.html.erb
@@ -11,15 +11,14 @@
           </div>
         <% end %>
         <div class="card-trip-status">
-
             <span class ="request-color">Pending <%= trip.bookings.where(booking_status: 0).count %></span>
             <span class ="approve-color">Confirmed  <%= trip.bookings.where(booking_status: 1).count %></span>
             <span class ="reject-color"> Cancelled <%= trip.bookings.where(booking_status: 0).count %></span>
-
-          </div>
+        </div>
       <% end %>
     </div>
   <% end %>
+  </div>
 </div>
 
 <div class="container container-booking">
@@ -57,3 +56,4 @@
       </div>
     </div>
   <% end %>
+</div>

--- a/app/views/bookings/new.html.erb
+++ b/app/views/bookings/new.html.erb
@@ -4,8 +4,6 @@
   <p><%= @trip.description %></p>
   <p> Bookings: <%= @trip.bookings.count %> </p>
 
-  <%= image_tag(@trip.image_url, class: "m-2 img-size2") %>
-
   <div class="d-flex mx-2 justify-content-between">
 
     <%= link_to "Go back to see all available Adventures", trips_path, class: "btn btn-tripl" %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,5 +1,5 @@
 <footer class="text-center bg-body-tertiary" id="footer">
-  <div class="d-flex flex-column justify-content-center">
+  <div class="d-flex flex-column justify-content-center align-items-center">
       <a
         data-mdb-ripple-init
         class="btn btn-link btn-floating btn-lg text-body m-1"


### PR DESCRIPTION
Main features:
- User can no longer book a trip they already booked
- Re-added pending/accept/reject booking for organizer's booking#index

For the pending/accept/reject, I just copied the bookings#index's formatting however it does not seem to be compatible 😅, for this we can either create a new component to contain it or try containing it inside the trips card for the organizer's dashboard (I vote the latter).

![image](https://github.com/komegi1215/Tripl/assets/146625275/da82e435-c154-4d63-b939-e58c194db8ad)

Minor changes:
- Changed card trips status to be the same as what is used in the pending/accept/reject (0-2 => 1-3).
- Footer icon link is taking the entire row, added class to only take its own size.